### PR TITLE
Hopeful or Partial fix For Custom Graphs

### DIFF
--- a/src/main/java/org/mcstats/handler/ReportHandler.java
+++ b/src/main/java/org/mcstats/handler/ReportHandler.java
@@ -167,7 +167,8 @@ public class ReportHandler extends AbstractHandler {
                 headers.put(headerName, request.getHeader(headerName));
             }
 
-            String pluginName = URLUtils.decode(getPluginName(request));
+            String rawName = getPluginName(request);
+            String pluginName = rawName == null ? null : URLUtils.decode(rawName);
 
             if (pluginName == null) {
                 finishRequest(null, ResponseType.ERROR, "Invalid arguments.", baseRequest, response);
@@ -498,6 +499,8 @@ public class ReportHandler extends AbstractHandler {
         String url = request.getRequestURI();
         if (url.startsWith("//report/")) {
             return url.substring("//report/".length());
+        } else if (url.startsWith("//plugin/")) {
+            return url.substring("//plugin/".length());
         } else if (url.startsWith("/report/")) {
             return url.substring("/report/".length());
         } else if (url.startsWith("/plugin/")) {


### PR DESCRIPTION
This change add a missing URL format that (I think?) is used in custom metrics. It also fixes an NPE when the plugin name fails to parse.

I couldn't fully test this, but would be willing to dig further- is the mysql schema available anywhere? I couldn't find it in the repo.

This did cause data processing to get farther in local testing, it was throwing an NPE on my plugin's data submission prior to this fix. It dies later on trying to lookup the Plugin now, but I think that's due to my empty metrics schema.

If you could take a look at all this, I'd hugely appreciate it- I would really love to see my custom metrics showing up. There may be a client-side fix or work-around for this as well, which I will be looking into :)
