### PR TITLE
Correctly identify BungeeCord servers.

### DIFF
--- a/server-definitions.txt
+++ b/server-definitions.txt
@@ -41,3 +41,4 @@ MinecraftForge                      Forge
 fml,forge                           Forge
 Canary                              Canary
 Bukkit                              CraftBukkit
+Bungee                              BungeeCord


### PR DESCRIPTION
At the moment BungeeCord servers are always displayed as `Unknown` in the frontend, I think this should fix that and display them correctly. :)
