### PR TITLE
Properly detect sponge server implementations

### DIFF
--- a/server-definitions.txt
+++ b/server-definitions.txt
@@ -45,3 +45,6 @@ Bungee                              BungeeCord
 canarybukkit                        CanaryBukkit
 pore                                Pore
 git-Cauldron                        Cauldron
+
+SpongeVanilla                       SpongeVanilla
+SpongeForge                         SpongeForge


### PR DESCRIPTION
I'm pretty sure they show up as unknown currently, so that should fix it. :)