### PR TITLE
Remove Pore server definition

### DIFF
--- a/server-definitions.txt
+++ b/server-definitions.txt
@@ -43,7 +43,6 @@ Canary                              Canary
 Bukkit                              CraftBukkit
 Bungee                              BungeeCord
 canarybukkit                        CanaryBukkit
-pore                                Pore
 git-Cauldron                        Cauldron
 
 SpongeVanilla                       SpongeVanilla


### PR DESCRIPTION
Pore isn't a real server implementation but rather just a bridge, so this is probably handled better if the servers get displayed as the underlying Sponge implementation and not as Pore.